### PR TITLE
feat: cache invalidation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -319,6 +330,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,6 +362,30 @@ checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crypto-common"
@@ -424,6 +468,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,6 +561,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -514,10 +590,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -861,6 +939,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cf62eb4dd975d2dde76432fb1075c49e3ee2331cf36f1f8fd4b66550d32b6f"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "event-listener",
+ "futures-util",
+ "once_cell",
+ "parking_lot",
+ "quanta",
+ "rustc_version",
+ "smallvec",
+ "tagptr",
+ "thiserror",
+ "triomphe",
+ "uuid",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +1064,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
@@ -1091,6 +1199,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1297,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
+dependencies = [
+ "bitflags 2.4.2",
 ]
 
 [[package]]
@@ -1305,6 +1437,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1407,6 +1548,12 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -1582,6 +1729,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tempfile"
 version = "3.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1603,6 +1756,7 @@ dependencies = [
  "clap",
  "handlebars",
  "log",
+ "moka",
  "reqwest",
  "serde",
  "serde_yaml",
@@ -1824,6 +1978,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "triomphe"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +2050,15 @@ name = "utf8parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
+name = "uuid"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ rust-version = "1.79"
 
 [dependencies]
 tracing = "0.1"
-tracing-subscriber ={ version = "0.3", features = ["json", "env-filter", "fmt"] }
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter", "fmt"] }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.9"
@@ -16,4 +16,5 @@ tokio = { version = "1.38", features = ["rt-multi-thread", "net", "macros"] }
 reqwest = { version = "0.12", features = ["rustls-tls", "json"] }
 axum = { version = "0.7" }
 anyhow = "1.0"
-cached ={ version = "0.52", features = ["async", "async_tokio_rt_multi_thread"] }
+cached = { version = "0.52", features = ["async", "async_tokio_rt_multi_thread"] }
+moka = { version = "0.12.8", features = ["future"] }

--- a/README.md
+++ b/README.md
@@ -98,3 +98,21 @@ mkcert localhost
 local-ssl-proxy --source 8081 --target 8080 --key localhost-key.pem --cert localhost.pem
 ```
 
+### Caching
+
+By default, Terustry will cache responses from Github/Gitlab for 10 minutes. This
+may result in an unwanted behaviour where a recently released version for a given
+provider is not available.
+
+The new version will become available once the cache is refreshed.
+
+However, if you need a faster refresh timing, for example in a CI/CD pipeline, you
+may request a specific cache entry to be invalidated using the following route:
+`GET /terraform/providers/v1/{namespace}/{provider_name}/invalidate`
+
+This should result in an empty 200 OK response.
+
+For example:
+```bash
+curl http://localhost:8080/terraform/providers/v1/hashicorp/hashicups/invalidate
+```

--- a/src/versions.rs
+++ b/src/versions.rs
@@ -1,19 +1,51 @@
+use std::time::Duration;
+
+use anyhow::Result;
+use moka::future::Cache;
 use reqwest::Client;
 
 use crate::conf::ConfigurationProvider;
 use crate::{github, gitlab};
 
-#[cached::proc_macro::cached(
-    result = true,
-    result_fallback = true,
-    time = 600,
-    key = "String",
-    convert = r#"{ format!("get_versions_{}", provider.name) }"#
-)]
-pub async fn get_versions(
+pub struct VersionClient {
+    versions_cache: Cache<String, Vec<String>>,
+}
+
+impl VersionClient {
+    pub fn new() -> Self {
+        Self {
+            versions_cache: Cache::builder()
+                .max_capacity(1_000)
+                .time_to_live(Duration::from_secs(5))
+                .build()
+        }
+    }
+
+    pub async fn invalidate(&self, provider: &ConfigurationProvider) {
+        let key = format!("get_version_{}", provider.name);
+        self.versions_cache.invalidate(&key).await
+    }
+
+    pub async fn get_versions(
+        &self,
+        client: &Client,
+        provider: &ConfigurationProvider,
+    ) -> Result<Vec<String>> {
+        let key = format!("get_version_{}", provider.name);
+        let result = self
+            .versions_cache
+            .try_get_with(key, fetch_versions(&client, &provider));
+        match result.await {
+            Ok(vec) => Ok(vec),
+            Err(_) => anyhow::bail!(format!("could not get versions for {}", provider.name))
+        }
+    }
+}
+
+pub async fn fetch_versions(
     client: &Client,
     provider: &ConfigurationProvider,
-) -> anyhow::Result<Vec<String>> {
+) -> Result<Vec<String>> {
     match provider.version.kind.as_str() {
         "gitlab" => match gitlab::versions(client, provider).await {
             Ok(vec) => Ok(vec),
@@ -29,6 +61,6 @@ pub async fn get_versions(
                 Err(err)
             }
         },
-        s => anyhow::bail!(format!("Provider type {} not found", s)),
+        s => anyhow::bail!(format!("provider type {} not found", s)),
     }
 }


### PR DESCRIPTION
This commit is designed to solve a caching issue
described here:
https://github.com/veepee-oss/terustry/issues/1

A new route is available to invalidate cache entries at: `/terraform/providers/v1/{namespace}/{provider_name}/invalidate`

This should ease integration in a CI pipeline.